### PR TITLE
:construction_worker: Cypress 실행을 위한 workflow 원복

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,20 @@
+name: End-to-end tests
+on: [push]
+jobs:
+  cypress-run:
+    name: Cypress run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Cypress run
+        uses: cypress-io/github-action@v1
+        with:
+          build: npm run build
+          start: npm start
+          wait-on: http://localhost:3000
+          record: true
+        env:
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_baseUrl }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           build: npm run build
           start: npm start
-          wait-on: http://localhost:3000
+          wait-on: '${{ secrets.CYPRESS_baseUrl }}'
           record: true
         env:
           CYPRESS_baseUrl: ${{ secrets.CYPRESS_baseUrl }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit tests
 
 on: [push]
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20923534/73132534-e8cc5f00-405f-11ea-962a-5bc596f7ab8e.png)

[Slack에 남겼던 내용](https://shipwreckworkspace.slack.com/archives/CSA2UEA2G/p1579953085001300)(Cypress.io가 CI 역할까지 해주는 줄 알았는데 그건 아니고 결과만 보여주는 서비스였음..) 이후 Cypress CI 설정 원복 및 record 옵션 추가했습니다. 위에 짤과 같이 CI의 테스트 결과를 대쉬보드에서 볼 수 있습니다.

`.github/workflows/e2e.yml`
- Github Workflow에서 E2E 테스트를 돌리고, 결과를 Cypress.io 서버로 전송합니다. (record 옵션. [reference](https://github.com/cypress-io/github-action#record-test-results-on-cypress-dashboard))
- Cypress에서 의존하는 환경 변수는 [이 Repo의 settings](https://github.com/shipwreck-project/boardconnect-client/settings/secrets)에 들어가 설정해주었습니다.

